### PR TITLE
check_files.pl: now able to sum the size of files (can do it using SSH) and search which file is bigger.

### DIFF
--- a/check_files.pl
+++ b/check_files.pl
@@ -618,7 +618,7 @@ if (defined($o_stdin)) {
 
     # I would have preferred open3 [# if (!open3($cin, $cout, $cerr, $shell_command))]
     # but there are problems when using it within nagios embedded perl
-    verb("Executing $shell_command 2>&1");
+    verb("Executing ".$shell_command." 2>&1");
     $ls_pid=open(SHELL_DATA, "$shell_command 2>&1 |");
     if (!$ls_pid) {
         print "UNKNOWN ERROR - could not execute $shell_command - $!";


### PR DESCRIPTION
Hello,

Here is some modifications we did on the script check_files.pl, we wanted to share this change with you ;-)

The script can check the size sum of searched files with "-S". It can also returns the biggest 
file from a list and with "-H" it can execute ls command remotly on a host using SSH.

**Here are the changes:**
- Added a new argument "-S [warn,crit]" to show the sum of the size of selected
  files.
- Added a new argument "-s [warn,crit]" to search for selected files which one
  is bigger.
- Performance data suppport for these new checks.
- Added a new argument "-H <IP_ADDRESS>" to execute the ls command on a remote
  host using SSH (used for host that does not have all Perl dependencies). Only
  public-key auth is supported.

**Examples:**

_Compute the sum size of files:_

```
$ ./check_files.pl -D /opt/oradata -F"t" -f -S -H "10.224.20.48"
OK - Sum of file sizes is 3897 octet, 2 t files found | 't'=2 size_sum=3897o
```

_Search largest file:_

```
$ ./check_files.pl -D /opt/oradata -F"t" -f -s -H "10.224.20.48"
OK - Largest size file is 3896 octet, 2 t files found | 't'=2 size_largest=3896o size_smallest=1o
```

_Combined:_

```
$ ./check_files.pl -D /opt/oradata -F"t" -f -S -s -H "10.224.20.48"
OK - Largest size file is 3896 octet, Sum of file sizes is 3897 octet, 2 t files found | 't'=2 size_largest=3896o size_smallest=1o size_sum=3897o
```

Warning and Critical thresholds can also be set.

Bye,
Patrick
