### PR TITLE
Add support for storing cached data in LONGSERVICEOUTPUT macro

### DIFF
--- a/check_netint.pl
+++ b/check_netint.pl
@@ -2649,7 +2649,7 @@ for (my $i=0;$i < $num_int; $i++) {
 	}
     }
     # output in octet counter
-    if (defined($o_perfo) || (defined($o_prevperf) && !defined($o_nagios_saveddata) && !defined($o_nagios_longoutput) ) {
+    if (defined($o_perfo) || (defined($o_prevperf) && !defined($o_nagios_saveddata) && !defined($o_nagios_longoutput))) {
 	# we add 'c' for graphing programs to know its a COUNTER
         $perf_out .= " ".perf_name($descr,"in_octet")."=". $interfaces[$i]{'in_bytes'}."c";
         $perf_out .= " ".perf_name($descr,"out_octet")."=". $interfaces[$i]{'out_bytes'}."c";

--- a/check_netint.pl
+++ b/check_netint.pl
@@ -2645,7 +2645,7 @@ for (my $i=0;$i < $num_int; $i++) {
 	}
     }
     # output in octet counter
-    if (defined($o_perfo) || (defined($o_prevperf) && !defined($o_nagios_saveddata))) {
+    if (defined($o_perfo) || (defined($o_prevperf))) {
 	# we add 'c' for graphing programs to know its a COUNTER
         $perf_out .= " ".perf_name($descr,"in_octet")."=". $interfaces[$i]{'in_bytes'}."c";
         $perf_out .= " ".perf_name($descr,"out_octet")."=". $interfaces[$i]{'out_bytes'}."c";


### PR DESCRIPTION
This:
    ./check_netint.pl -H 172.16.203.172 -C public -n "eth\d+|em\d+" -f -q -k -y -M -B -m -P "DATA: cache_descr_ids=2 cache_descr_names=eth0 cache_descr_time=1383918585 'eth0_in_octet'=3326101411 'eth0_out_octet'=933507763 'eth0_in_octet.1383849652'=2790378964 'eth0_out_octet.1383849652'=533846849 ptime=1383918385" -T 1383918585 -e -z --nagios_longoutput

Outputs the following:
    eth0:UP (0.0Mbps/0.0Mbps/0.0/0.0/0.0/0.0) (1 UP): OK |  'eth0_in_prct'=0% 'eth0_out_prct'=0% 'eth0_in_error'=0 'eth0_out_error'=0 'eth0_in_discard'=0 'eth0_out_discard'=0
    DATA: cache_descr_ids=2 cache_descr_names=eth0 cache_descr_time=1383918585 'eth0_in_octet'=3326494996 'eth0_out_octet'=933967457 'eth0_in_octet.1383918385'=3326101411 'eth0_out_octet.1383918385'=933507763 ptime=1383918621

... which is valid PERFDATA. Without this option the -P option produces invalid PERFDATA and graphing tools reject it (e.g php4nagios).
