### PR TITLE
Fix issue #48, missing '\' on '\s' perl regexp

### DIFF
--- a/check_uptime.pl
+++ b/check_uptime.pl
@@ -540,7 +540,7 @@ if ($check_type==1) {  # local
   elsif ($uptime_output =~ /up\s+(\d+)\s+min/) {
      ($days, $hrs, $mins) = (0,0,$1);
   }
-  elsif ($uptime_output =~ /up\s+(\d+)s+days?,s+(\d+)s+min/) {
+  elsif ($uptime_output =~ /up\s+(\d+)\s+days?,\s+(\d+)\s+min/) {
      ($days, $hrs, $mins) = ($1,0,$2);
   }
   else {


### PR DESCRIPTION
With this fix:

$ uptime 
11:55:38 up 189 days, 20 min,  3 users,  load average: 0.06, 0.08, 0.04

$ ./check_uptime.pl -f
OK: Linux myhost.domain.com 2.6.32-358.18.1.el6.x86_64 - up 189 days 20 minutes | type=1 uptime_minutes=272180
