### PR TITLE
Changed /usr/lib to /usr/lib64

### DIFF
--- a/check_netsnmp_memory.pl
+++ b/check_netsnmp_memory.pl
@@ -76,7 +76,7 @@ my @expressions_netsnmpmem = (
 	'%buffer_real=buffer,total_real,%',		# Percent of buffer memory in relation to total real
    );
 
-use lib "/usr/lib/nagios/plugins";
+use lib "/usr/lib64/nagios/plugins";
 require "check_snmp_attributes.pl";
 process_expressions(@expressions_netsnmpmem);
 run_plugin();

--- a/check_snmp_attributes.pl
+++ b/check_snmp_attributes.pl
@@ -1173,7 +1173,7 @@ sub func_snmp_proc {
     }
 
      # Get NetSNMP memory values
-     $resultat = (Net::SNMP->VERSION < 4) ?
+     $resultat = (Net::SNMP->VERSION lt v4) ?
 		$session->get_request(@nets_oid_array)
 		:$session->get_request(-varbindlist => \@nets_oid_array);
 


### PR DESCRIPTION
Had an issue with this in CentOS7 so I changed it to /usr/lib64. Not sure if this will become the default location across distros. 
